### PR TITLE
Add type guards support to "where"

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -459,6 +459,12 @@ export interface IEnumerable<T> extends Iterable<T> {
    * Method filters an iterable based on a predicate.
    * @param predicate A function to test each source element and its number for a condition.
    */
+  where<TResult extends T>(predicate: (element: T, index: number) => element is TResult): IEnumerable<TResult>;
+
+  /**
+   * Method filters an iterable based on a predicate.
+   * @param predicate A function to test each source element and its number for a condition.
+   */
   where(predicate: (element: T, index: number) => boolean): IEnumerable<T>;
 }
 


### PR DESCRIPTION
See TypeScript `Array.prototype.filter()` types for more details

https://github.com/microsoft/TypeScript/blob/716441d343faa15417ec558c60addfc6a2e75a3d/lib/lib.es5.d.ts#L1176